### PR TITLE
Add filename to graph's header 

### DIFF
--- a/contributions/render_html.py
+++ b/contributions/render_html.py
@@ -13,6 +13,7 @@ This module is responsible for preparing and rendering the templates.
 from collections import namedtuple
 import datetime
 from types import StringTypes
+import ntpath
 
 from jinja2 import Environment, PackageLoader
 
@@ -44,6 +45,7 @@ def create_graph(filepaths):
                 [key for key, val in contributions.iteritems() if val > 0]
             ),
             "sum": sum(contributions.itervalues()),
+            "repo_name": ntpath.basename(path)
         }
 
         graph["last_date"] = (

--- a/contributions/templates/graph.html
+++ b/contributions/templates/graph.html
@@ -1,6 +1,6 @@
 {%- set data = graph.data -%}
 <div class="panel panel-default">
-      <div class="panel-heading">Contributions</div>
+      <div class="panel-heading">Contributions for <code>{{ graph.repo_name }}</code></div>
       <div class="panel-body">
         <center>
         <div class="contributions-graph">


### PR DESCRIPTION
The filename is extracted and added to the graph.
This will allow the template to use this filename in the display,
linking each graph to the file that it originated from.

`ntpath` is used here because of https://stackoverflow.com/q/8384737/281089

Note that the whole filename is used, including extensions.
I have deliberately not tried to remove the extension as that will
be additional (albeit minor) work that is not strictly required.
Simply removing the extension from the filename should be sufficient.
However, if this is not adequate, this removal can be added in.

Screenshot of it in action: 
![multiple_graphs_example](https://user-images.githubusercontent.com/252960/30271015-9eac1610-96e6-11e7-8b45-02d7c9cb961f.png)
