### PR TITLE
Account for months where name in last in list

### DIFF
--- a/contributions/render_html.py
+++ b/contributions/render_html.py
@@ -174,6 +174,7 @@ def filter_months(months):
     # heading
     indices = [idx for idx, month in enumerate(months) if month]
     for idx in reversed(indices):
-        del months[idx+1]
+        if idx != len(months) - 1:
+            del months[idx+1]
 
     return months


### PR DESCRIPTION
If the month name is the last item in the list `months, then `idx+1` throws an error as it is out of bounds.
This change will allow the deletion to take place only if the month is not the last index.

## Sample case

If `indices` is `[4, 9, 13, 17, 22, 26, 30, 35, 39, 43, 48, 52]` and `months` is `['', '', '', '', 'Oct', '', '', '', '', 'Nov', '', '', '', 'Dec', '', '', '', 'Jan', '', '', '', '', 'Feb', '', '', '', 'Mar', '', '', '', 'Apr', '', '', '', '', 'May', '', '', '', 'Jun', '', '', '', 'Jul', '', '', '', '', 'Aug', '', '', '', 'Sep']` with a length of `53`. 
Here, `Sep` is the last item in the list so when `idx` is `52` (the first time the loop runs), `months[idx+1]` becomes `months[53]` which is an error. 

Luckily, we do not need to delete any cells if the month is the last item in the list.